### PR TITLE
Expose port 80 from the frontend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - dhparam_cache:/cache
     ports:
       - "443:443"
+      - "80:80"
     links:
       - grafana
 


### PR DESCRIPTION
This is required in order for the Let's Encrypt certificates to be issued.

Closes #1.